### PR TITLE
Add Blocks Toolkit property editor to palette sidebar

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -39,11 +39,8 @@ import com.google.appinventor.client.tracking.Tracking;
 import com.google.appinventor.client.utils.HTML5DragDrop;
 import com.google.appinventor.client.utils.PZAwarePositionCallback;
 import com.google.appinventor.client.widgets.DropDownButton;
-import com.google.appinventor.client.widgets.ExpiredServiceOverlay;
-import com.google.appinventor.client.widgets.boxes.Box;
-import com.google.appinventor.client.widgets.boxes.ColumnLayout.Column;
-import com.google.appinventor.client.widgets.boxes.ColumnLayout;
 import com.google.appinventor.client.widgets.boxes.WorkAreaPanel;
+import com.google.appinventor.client.widgets.properties.EditableProperty;
 import com.google.appinventor.client.wizards.NewProjectWizard.NewProjectCommand;
 import com.google.appinventor.client.wizards.TemplateUploadWizard;
 import com.google.appinventor.common.version.AppInventorFeatures;
@@ -209,6 +206,8 @@ public class Ode implements EntryPoint {
   @UiField(provided = true) DeckPanel deckPanel;
   @UiField(provided = true) FlowPanel overDeckPanel;
   @UiField TutorialPanel tutorialPanel;
+  @UiField HorizontalPanel horizontalBlocksPanel;
+
   private int projectsTabIndex;
   private int designTabIndex;
   private int debuggingTabIndex;
@@ -384,6 +383,10 @@ public class Ode implements EntryPoint {
 
   public FlowPanel getOverDeckPanel() {
     return overDeckPanel;
+  }
+
+  public void addPropertyToDesigner(EditableProperty property) {
+    horizontalBlocksPanel.add(property.getEditor());
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -206,7 +206,8 @@ public class Ode implements EntryPoint {
   @UiField(provided = true) DeckPanel deckPanel;
   @UiField(provided = true) FlowPanel overDeckPanel;
   @UiField TutorialPanel tutorialPanel;
-  @UiField HorizontalPanel horizontalBlocksPanel;
+  @UiField FlowPanel toolkitEditor;
+  @UiField Label blocksLabel;
 
   private int projectsTabIndex;
   private int designTabIndex;
@@ -386,7 +387,8 @@ public class Ode implements EntryPoint {
   }
 
   public void addPropertyToDesigner(EditableProperty property) {
-    horizontalBlocksPanel.add(property.getEditor());
+    blocksLabel.setText(property.getCaption());
+    toolkitEditor.add(property.getEditor());
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.ui.xml
@@ -5,6 +5,8 @@
              xmlns:ex="urn:import:com.google.appinventor.client.explorer.youngandroid"
              xmlns:ode="urn:import:com.google.appinventor.client"
              xmlns:box="urn:import:com.google.appinventor.client.boxes"
+             xmlns:p="urn:import:com.google.appinventor.client.editor.simple.palette"
+             xmlns:s="urn:import:com.google.appinventor.client.widgets.properties"
              ui:generatedFormat="com.google.gwt.i18n.server.PropertyCatalogFactory"
              ui:generatedKeys="com.google.gwt.i18n.server.keygen.MethodNameKeyGenerator"
              ui:generateLocales="default">
@@ -20,7 +22,14 @@
         <g:FlowPanel styleName="ode-ProjectEditor" ui:field="projectEditor">
           <ed:DesignToolbar ui:field="bindDesignToolbar" />
           <g:FlowPanel ui:field="workColumns" styleName="ode-WorkColumns">
-            <box:PaletteBox width="240px" ui:field="paletteBox"/>
+            <g:FlowPanel width="240px">
+            <g:HorizontalPanel ui:field="horizontalBlocksPanel" width="100%">
+              <g:Label text="BlocksToolkit:" ui:field="blocksLabel" width="40%"/>
+              <p:ComponentHelpWidget name="Blocks Toolkit" helpString="A JSON string representing the subset for the screen. Authors of template apps can use this to control what components, designer properties, and blocks are available in the project."
+                                     helpURL="http://ai2.appinventor.mit.edu/reference/components/userinterface.html#Screen"/>
+            </g:HorizontalPanel>
+            <box:PaletteBox width="100%" ui:field="paletteBox"/>
+            </g:FlowPanel>
             <box:ViewerBox ui:field="bindViewerBox" />
             <g:FlowPanel ui:field="structureAndAssets">
               <box:SourceStructureBox ui:field="bindSourceStructureBox" />

--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.ui.xml
@@ -24,7 +24,8 @@
           <g:FlowPanel ui:field="workColumns" styleName="ode-WorkColumns">
             <g:FlowPanel width="240px">
             <g:HorizontalPanel ui:field="horizontalBlocksPanel" width="100%">
-              <g:Label text="BlocksToolkit:" ui:field="blocksLabel" width="40%"/>
+              <g:Label  ui:field="blocksLabel" width="40%"/>
+              <g:FlowPanel ui:field="toolkitEditor" />
               <p:ComponentHelpWidget name="Blocks Toolkit" helpString="A JSON string representing the subset for the screen. Authors of template apps can use this to control what components, designer properties, and blocks are available in the project."
                                      helpURL="http://ai2.appinventor.mit.edu/reference/components/userinterface.html#Screen"/>
             </g:HorizontalPanel>

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperties.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperties.java
@@ -6,7 +6,9 @@
 
 package com.google.appinventor.client.widgets.properties;
 
+import com.google.appinventor.client.Ode;
 import com.google.appinventor.client.properties.Properties;
+import com.google.appinventor.shared.settings.SettingsConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -105,7 +107,9 @@ public class EditableProperties extends Properties<EditableProperty> {
    */
   void addToPropertiesPanel(PropertiesPanel panel) {
     for (EditableProperty property : this) {
-      if (property.isVisible()) {
+      if (property.getName().equals(SettingsConstants.YOUNG_ANDROID_SETTINGS_BLOCK_SUBSET)) {
+        Ode.getInstance().addPropertyToDesigner(property);
+      } else if (property.isVisible()) {
         panel.addProperty(property);
       }
     }


### PR DESCRIPTION
This is bare-bones code to make the Blocks Toolkit available on the left sidebar of the designer using UI Binder.